### PR TITLE
Order independent properties

### DIFF
--- a/resources/svl.lark
+++ b/resources/svl.lark
@@ -12,6 +12,8 @@ hcat: "CONCAT" "(" chart+ ")"
 
 chart: xy_chart | histogram_chart | pie_chart | vcat | hcat
 
+// The XX_property directives include the dimensions, so at least that one
+// is required. That will have to be enforced in the compiler though.
 xy_chart: markxy data xy_property+
 
 histogram_chart: "HISTOGRAM" data histogram_property+

--- a/resources/svl.lark
+++ b/resources/svl.lark
@@ -12,11 +12,17 @@ hcat: "CONCAT" "(" chart+ ")"
 
 chart: xy_chart | histogram_chart | pie_chart | vcat | hcat
 
-xy_chart: markxy data title? dimensions filter?
+xy_chart: markxy data xy_property+
 
-histogram_chart: "HISTOGRAM" data title? field histogram_opts? filter?
+histogram_chart: "HISTOGRAM" data histogram_property+
 
-pie_chart: "PIE" data title? field pie_opts? filter?
+pie_chart: "PIE" data pie_property+
+
+?xy_property: title | dimensions | filter
+
+?histogram_property: title | field_explicit | histogram_opts | filter
+
+?pie_property: title | field_explicit | pie_opts | filter
 
 title: "TITLE" ESCAPED_STRING
 
@@ -28,7 +34,7 @@ data: CNAME
 
 dimensions: (x | y | split_by)+
 
-histogram_opts: (step | bins) label?
+histogram_opts: step | bins
 
 pie_opts: hole
 
@@ -42,16 +48,20 @@ hole: "HOLE" NUMBER
 // order ambiguity (i.e. which aggregation gets applied first?).
 // TODO: Find a way to enforce only one aggregation transformation
 // between x and y.
-x: "X" ((aggregation field) | (field temporal?)) label?
+x: "X" aggregation? field
 
-y: "Y" ((aggregation field) | (field temporal?)) label?
+y: "Y" aggregation? field
 
 label: "LABEL" ESCAPED_STRING
 
 // For split by temporal is supported irrespective of x and y.
-split_by: "SPLIT" "BY" field? temporal?
+split_by: "SPLIT" "BY" field
 
-field: CNAME
+?field_explicit: "FIELD" field
+
+field: CNAME field_property*
+
+?field_property: temporal | label
 
 aggregation: COUNT | MIN | MAX | AVG
 

--- a/scripts/test.svl
+++ b/scripts/test.svl
@@ -16,30 +16,27 @@ CONCAT(
             Y COUNT temperature_mid LABEL "Number of Sightings"
         PIE bigfoot
             TITLE "Bigfoot Sightings by Classification"
-            classification
             HOLE 0.3
+            FIELD classification
     )
     
     (
         CONCAT(
             HISTOGRAM bigfoot
                 TITLE "Bigfoot Sighting High Temperature"
-                temperature_high
+                FIELD temperature_high LABEL "Temperature (F)"
                 BINS 25
-                LABEL "Temperature (F)"
 
             HISTOGRAM bigfoot
-                TITLE "Bigfoot Sighting Low Temperature"
-                temperature_low
                 BINS 25
-                LABEL "Temperature (F)"
+                FIELD temperature_low LABEL "Temperature (F)"
+                TITLE "Bigfoot Sighting Low Temperature"
         )
     
         HISTOGRAM bigfoot
-            TITLE "Bigfoot Sighting Mid Temperature"
-            temperature_mid
             BINS 25
-            LABEL "Temperature (F)"
+            TITLE "Bigfoot Sighting Mid Temperature"
+            FIELD temperature_mid LABEL "Temperature (F)"
         
 
     )

--- a/svl/svl.py
+++ b/svl/svl.py
@@ -89,7 +89,14 @@ class SVLTransformer(lark.Transformer):
         return {"split_by": merge(*items)}
 
     def field(self, items):
-        return {"field": str(items[0])}
+        if len(items) == 1:
+            return {"field": str(items[0])}
+        else:
+            print(items)
+            return merge(
+                {"field": str(items[0])},
+                *items[1:]
+            )
 
     def temporal(self, items):
         return {"temporal": str(items[0])}

--- a/test/test_scripts/histogram.svl
+++ b/test/test_scripts/histogram.svl
@@ -2,4 +2,4 @@ DATASETS
     bigfoot "{{ test_dir }}/test_datasets/bigfoot_sightings.csv"
 
 HISTOGRAM bigfoot
-    temperature_mid BINS 25
+    FIELD temperature_mid BINS 25

--- a/test/test_svl.py
+++ b/test/test_svl.py
@@ -9,10 +9,10 @@ def test_line_chart():
     DATASETS
         bigfoot "data/bigfoot_sightings.csv"
     LINE bigfoot
-        TITLE "Bigfoot Sightings by Year and Classification"
         X date BY YEAR LABEL "Year"
         Y COUNT date LABEL "Number of Sightings"
         SPLIT BY classification
+        TITLE "Bigfoot Sightings by Year and Classification"
         FILTER "date > '1990-01-01'"
     """
 
@@ -87,7 +87,8 @@ def test_histogram_step():
     DATASETS
         bigfoot "data/bigfoot_sightings.csv"
     HISTOGRAM bigfoot
-        temperature_mid STEP 5
+        FIELD temperature_mid
+        STEP 5
     """
 
     parsed_svl_truth = {
@@ -116,7 +117,8 @@ def test_histogram_bins():
         bigfoot "data/bigfoot_sightings.csv"
     HISTOGRAM bigfoot
         TITLE "Bigfoot Sighting Humidity"
-        humidity BINS 25 LABEL "Humidity"
+        BINS 25
+        FIELD humidity LABEL "Humidity"
     """
 
     parsed_svl_truth = {
@@ -145,8 +147,8 @@ def test_pie():
         bigfoot "data/bigfoot_sightings.csv"
     PIE bigfoot
         TITLE "Bigfoot Sightings by Classification"
-        classification
         HOLE 0.3
+        FIELD classification
     """
 
     parsed_svl_truth = {


### PR DESCRIPTION
Rearranges the grammar such that certain properties (i.e. titles and filters) can be specified order-independently. Others, such as labels, must be attached to their corresponding fields.

Also added a new FIELD keyword for histograms and pie charts to make the parse deterministic.