### PR TITLE
CLI datasets

### DIFF
--- a/resources/svl.lark
+++ b/resources/svl.lark
@@ -1,6 +1,6 @@
 ?start: visualization
 
-?visualization: datasets charts
+?visualization: datasets? charts
 
 datasets: "DATASETS"i dataset+
 

--- a/svl/cli.py
+++ b/svl/cli.py
@@ -8,6 +8,10 @@ from svl.plotly import plotly_template, plotly_template_vars
 from svl.sqlite import create_datasets, get_svl_data
 
 
+def _extract_cli_datasets(datasets):
+    return dict(map(lambda x: x.split("="), datasets))
+
+
 @click.command()
 @click.argument("svl_source", type=click.File('r'))
 @click.option("--debug", is_flag=True)
@@ -21,16 +25,19 @@ from svl.sqlite import create_datasets, get_svl_data
     type=click.File("w"),
     default="visualization.html"
 )
+@click.option("--dataset", "-d", multiple=True)
 @click.option("--no-browser", is_flag=True)
-def cli(svl_source, debug, backend, output_file, no_browser):
+def cli(svl_source, debug, backend, output_file, dataset, no_browser):
 
     svl_string = svl_source.read()
-
     if debug:
         print(svl.parse_svl(svl_string, debug=True).pretty())
         return
 
-    svl_spec = svl.parse_svl(svl_string)
+    # Extract the datasets from the CLI.
+    cli_datasets = _extract_cli_datasets(dataset)
+
+    svl_spec = svl.parse_svl(svl_string, **cli_datasets)
 
     # Create a connection to the sqlite database (eventually this will be
     # abstracted a little better but for now sqlite's all we've got).

--- a/svl/svl.py
+++ b/svl/svl.py
@@ -1,7 +1,7 @@
 import lark
 import pkg_resources
 
-from toolz import merge
+from toolz import merge, get
 
 
 class SVLTransformer(lark.Transformer):
@@ -119,8 +119,16 @@ parser = lark.Lark(
 )
 
 
-def parse_svl(svl_string, debug=False):
+def parse_svl(svl_string, debug=False, **kwargs):
     if debug:
         return debug_parser.parse(svl_string)
     else:
-        return parser.parse(svl_string)
+        parsed_svl = parser.parse(svl_string)
+        parsed_svl["datasets"] = merge(
+            # Either DATASETS is there or is empty.
+            get("datasets", parsed_svl, {}),
+            # Convert each kwarg into a file dataset spec.
+            {k: {"file": v} for k, v in kwargs.items()}
+        )
+
+        return parsed_svl

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -4,6 +4,9 @@ import os
 
 from jinja2 import Environment, FileSystemLoader
 
+from svl.cli import _extract_cli_datasets
+
+
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 SVL_SCRIPT_TEMPLATE_DIR = os.path.join(CURRENT_DIR, "test_scripts")
 JINJA_ENV = Environment(loader=FileSystemLoader(SVL_SCRIPT_TEMPLATE_DIR))
@@ -59,6 +62,25 @@ def output_path():
     os.remove(output_path)
 
 
+def test_extract_cli_datasets():
+    """ Tests that the _extract_cli_datasets function returns the correct
+        value.
+    """
+    datasets = (
+        "bigfoot=bigfoot_sightings.csv",
+        "mothman=mothman_sightings.parquet"
+    )
+
+    truth = {
+        "bigfoot": "bigfoot_sightings.csv",
+        "mothman": "mothman_sightings.parquet"
+    }
+
+    answer = _extract_cli_datasets(datasets)
+
+    assert truth == answer
+
+
 def test_histogram_cli_debug(svl_script_template):
     """ Tests that the command line interface works correctly on the test
         dataset for histogram plots when debug is turned on.
@@ -85,6 +107,24 @@ def test_histogram_cli_plotly(svl_script_template, output_path):
     subprocess.run([
         "svl",
         svl_script_template("histogram.svl"),
+        "--output-file", output_path,
+        "--backend", "plotly",
+        "--no-browser"
+    ], check=True)
+
+
+def test_histogram_cli_no_datasets(output_path):
+    """ Tests that the command line interface works correctly on the test
+        dataset for histogram plots when the test dataset is passed in via
+        command line.
+    """
+    subprocess.run([
+        "svl",
+        # NOTE Don't need the template here because there are no templated
+        # parts here.
+        "{}/test_scripts/histogram_no_datasets.svl".format(CURRENT_DIR),
+        "--dataset",
+        "bigfoot={}/test_datasets/bigfoot_sightings.csv".format(CURRENT_DIR),
         "--output-file", output_path,
         "--backend", "plotly",
         "--no-browser"

--- a/test/test_scripts/histogram_no_datasets.svl
+++ b/test/test_scripts/histogram_no_datasets.svl
@@ -1,0 +1,2 @@
+HISTOGRAM bigfoot
+    X temperature_mid BINS 25

--- a/test/test_svl.py
+++ b/test/test_svl.py
@@ -454,3 +454,31 @@ def test_sql_dataset():
     parsed_svl_answer = parse_svl(svl_string)
 
     assert parsed_svl_truth == parsed_svl_answer
+
+
+def test_no_datasets():
+    """ Tests that the parse_svl function returns the correct value when
+        there's no DATASETS directive.
+    """
+    svl_string = """
+    HISTOGRAM bigfoot
+        X temperature_mid
+        SPLIT BY classification
+    """
+
+    truth = {
+        "vcat": [{
+            "data": "bigfoot",
+            "type": "histogram",
+            "x": {
+                "field": "temperature_mid"
+            },
+            "split_by": {
+                "field": "classification"
+            }
+        }]
+    }
+
+    answer = parse_svl(svl_string)
+
+    assert truth == answer

--- a/test/test_svl.py
+++ b/test/test_svl.py
@@ -467,6 +467,10 @@ def test_no_datasets():
     """
 
     truth = {
+        "datasets": {
+            # A validator would catch this, but from a parsing perspective this
+            # is valid.
+        },
         "vcat": [{
             "data": "bigfoot",
             "type": "histogram",
@@ -480,5 +484,38 @@ def test_no_datasets():
     }
 
     answer = parse_svl(svl_string)
+
+    assert truth == answer
+
+
+def test_with_kwargs():
+    """ Tests that the parse_svl function returns the correct value when the
+        kwargs are used.
+    """
+    svl_string = """
+    HISTOGRAM bigfoot
+        X temperature_mid
+        SPLIT BY classification
+    """
+
+    truth = {
+        "datasets": {
+            "bigfoot": {
+                "file": "bigfoot_sightings.csv"
+            }
+        },
+        "vcat": [{
+            "data": "bigfoot",
+            "type": "histogram",
+            "x": {
+                "field": "temperature_mid"
+            },
+            "split_by": {
+                "field": "classification"
+            }
+        }]
+    }
+
+    answer = parse_svl(svl_string, bigfoot="bigfoot_sightings.csv")
 
     assert truth == answer


### PR DESCRIPTION
Adds the ability to inject datasets into the script via command line options:

```
svl script.svl --dataset haunted=haunted_places.csv
```

would make `haunted_places.csv` available as a dataset in the SVL script without explicitly declaring it.
Also, `DATASETS` is now fully optional.