### PR TITLE
Split by modifiers

### DIFF
--- a/docs/reference/syntax_reference.md
+++ b/docs/reference/syntax_reference.md
@@ -161,10 +161,12 @@ Temporal is one of `YEAR`, `MONTH`, `DAY`, `HOUR`, `MINUTE`, `SECOND`.
 ## `SPLIT BY`
 
 ```
-SPLIT BY field_identifier
+SPLIT BY {field_identifier | TRANSFORM quoted_string} [BY temporal | LABEL quoted_string], ...
 ```
 
-Currently `SPLIT BY` does not take modifiers, but there are plans for that (see [this issue](https://github.com/timothyrenner/svl/issues/33)).
+The quoted string following `TRANSFORM` must be a valid SQL SELECT expression.
+Temporal is one of `YEAR`, `MONTH`, `DAY`, `HOUR`, `MINUTE`, `SECOND`.
+For the Plotly backend (currently the only one available), `LABEL` is a no-op, since adding legend titles to charts is fairly challenging for Plotly plots.
 
 ## `COLOR BY`
 

--- a/docs/reference/under_the_hood.md
+++ b/docs/reference/under_the_hood.md
@@ -66,7 +66,7 @@ Either of the plots inside the `hcat` could itself be an `hcat` or `vcat` ... an
 ## Flattening the Plot Tree
 
 Trees are nice inside a programming environment, but I need these plots to get rendered onto a web page, which means I need to project the tree onto a grid.
-I implemented plot layouts with [CSS grids]() because they're pretty straightforward once you get your head around it.
+I implemented plot layouts with [CSS grids](https://css-tricks.com/snippets/css/complete-guide-grid/) because they're pretty straightforward once you get your head around it.
 Basically, CSS grids need a layout declaration, and each element in the grid needs a position.
 
 So I need to go from tree of plots to a list of plots that have grid positions.
@@ -140,12 +140,12 @@ It's the only time I've ever used TDD (it worked very well for this).
 ## Loading the SQLite DB
 
 This piece is pretty straightforward.
-Because I'm ~~lazy~~ efficient, I decided to use [pandas]() to read the files and load the SQLite database.
+Because I'm ~~lazy~~ efficient, I decided to use [pandas](https://pandas.pydata.org/) to read the files and load the SQLite database.
 Files are loaded first, then the SQL datasets are constructed in the order they appear in the script.
 
 ## Retrieving the Plot Data
 
-This functionality is the proud home of probably the [worst](https://github.com/timothyrenner/svl/blob/master/svl/sqlite.py#L351) code of the whole compiler (I'm going to refactor it soon because it makes my eyes bleed), but the functionality _in principle_ is simple.
+This functionality is the proud home of probably the [worst](https://github.com/timothyrenner/svl/blob/master/svl/sqlite.py#L340) code of the whole compiler (I'm going to refactor it soon because it makes my eyes bleed), but the functionality _in principle_ is simple.
 It translates the SVL plot specifier (after flattening) into a SQL query, then marshals those results into something that can be injected into a Plotly data structure.
 
 For example, consider the following plot.

--- a/docs/tutorials/advanced_svl.md
+++ b/docs/tutorials/advanced_svl.md
@@ -222,8 +222,7 @@ Just like with `FILTER`, everything in quotes after `TRANSFORM` literally gets p
 SVL has _no idea_ what's in those quotes, so keeping it simple is probably a good idea.
 
 Also, `TRANSFORM` replaces a field specifier in an axis declaration.
-It can apply to `X`, `Y`, `AXIS` and `COLOR BY`.
-Currently it does _not_ work on `SPLIT BY` due to a technical oversight on the part of the language author (🙋‍♂ hey that's me - see details [here](https://github.com/timothyrenner/svl/issues/33)), but hopefully I can get that fixed pretty soon.
+It can apply to `X`, `Y`, `AXIS`, `COLOR BY`, and `SPLIT BY`.
 
 ### Custom Datasets
 

--- a/docs/tutorials/basic_svl.md
+++ b/docs/tutorials/basic_svl.md
@@ -144,8 +144,9 @@ This plot counts the number of sightings by year.
 
 This plot also introduces a **temporal transformation**.
 Basically, SVL truncates each date at the year and then counts each year's worth of sightings.
-Currently only `YYYY-mm-ddTH:M:S` format is supported but it should be straightforward to support custom formats in the future.
+Currently only `YYYY-mm-ddTH:MM:S` format is supported but it should be straightforward to support custom formats in the future.
 The following temporal transformations are available: `YEAR`, `MONTH`, `DAY`, `HOUR`, `MINUTE`, `SECOND`.
+Temporal transformations can be applied to `X`, `Y`, `COLOR BY` and `SPLIT BY` axes (more on those last two shortly).
 
 ### PIE
 
@@ -232,10 +233,11 @@ It looks like this:
 
 `TITLE` can appear anywhere after the plot declaration (i.e. `HISTOGRAM bigfoot`).
 `LABEL` can appear anywhere after the axis declaration (i.e. `X moon_phase`).
+`LABEL` is valid SVL syntax for `SPLIT BY` but doesn't do anything for Plotly, because they don't currently have a straightforward way to add legend titles to plots.
 
 ✅ **VALID AXIS LABEL**: `X moon_phase LABEL "Moon Phase"`
 
-❌ **INVALID AXIS LABEL**: `X LABEL "Moon Phase" moon_phase``
+❌ **INVALID AXIS LABEL**: `X LABEL "Moon Phase" moon_phase`
 
 For completeness here's a fully beautified example of our earlier results.
 

--- a/resources/svl.lark
+++ b/resources/svl.lark
@@ -19,7 +19,7 @@ hcat: "CONCAT"i "(" chart+ ")"
 chart: xy_chart | histogram_chart | pie_chart | vcat | hcat
 
 // The XX_property directives include the dimensions, so at least that one
-// is required. That will have to be enforced in the compiler though.
+// is required. This is enforced by the compiler.
 xy_chart: markxy data xy_property+
 
 histogram_chart: "HISTOGRAM"i data histogram_property+
@@ -54,8 +54,7 @@ hole: "HOLE"i NUMBER
 
 // This allows for both x and y to have aggregations, which results in
 // order ambiguity (i.e. which aggregation gets applied first?).
-// TODO: Find a way to enforce only one aggregation transformation
-// between x and y.
+// This is resolved in the compiler.
 x: "X"i axis_spec axis_modifier*
 
 y: "Y"i axis_spec axis_modifier*
@@ -72,9 +71,9 @@ axis: "AXIS"i axis_spec axis_modifier*
 
 label: "LABEL"i ESCAPED_STRING
 
-// For split by temporal is supported irrespective of x and y.
-// DANGER - SPLIT BY DOES NOT CURRENTLY SUPPORT TEMPORALS BUT IT SHOULD.
-split_by: "SPLIT"i "BY"i field
+split_by: "SPLIT"i "BY"i axis_spec split_by_modifier*
+
+?split_by_modifier: temporal | label
 
 field: CNAME
 

--- a/svl/plotly/plotly.py
+++ b/svl/plotly/plotly.py
@@ -1,9 +1,29 @@
 from toolz import merge, compose, pluck, get, dissoc, get_in
 from jinja2 import Environment, PackageLoader, select_autoescape
 
-from svl.sqlite import _get_field
 
 listpluck = compose(list, pluck)
+
+
+def _get_field_name(svl_axis):
+    """ Extracts the name of the field for the SVL plot.
+
+    Parameters
+    ----------
+    svl_axis : dict
+        The SVL axis specifier.
+
+    Returns
+    -------
+    str
+        The name of the field in the axis, or the transform statement.
+    """
+    if "transform" in svl_axis:
+        return svl_axis["transform"]
+    elif "field" in svl_axis:
+        return svl_axis["field"]
+    else:
+        return "*"
 
 
 def _extract_all_traces(svl_plot, data):
@@ -46,18 +66,20 @@ def _get_title(svl_plot):
     if "title" in svl_plot:
         return svl_plot["title"]
     elif svl_plot["type"] == "pie":
-        return "{}: {}".format(svl_plot["data"], _get_field(svl_plot["axis"]))
+        return "{}: {}".format(
+            svl_plot["data"], _get_field_name(svl_plot["axis"])
+        )
     elif svl_plot["type"] == "histogram":
         svl_axis = "x" if "x" in svl_plot else "y"
         return "{}: {}".format(
-            svl_plot["data"], _get_field(svl_plot[svl_axis])
+            svl_plot["data"], _get_field_name(svl_plot[svl_axis])
         )
     else:
         # xy plot
         return "{}: {} - {}".format(
             svl_plot["data"],
-            _get_field(svl_plot["x"]),
-            _get_field(svl_plot["y"]),
+            _get_field_name(svl_plot["x"]),
+            _get_field_name(svl_plot["y"]),
         )
 
 
@@ -84,11 +106,11 @@ def _get_axis_label(svl_plot, axis):
     elif "agg" in svl_plot[axis]:
         # If there's an aggregation, include it.
         return "{} ({})".format(
-            _get_field(svl_plot[axis]), svl_plot[axis]["agg"]
+            _get_field_name(svl_plot[axis]), svl_plot[axis]["agg"]
         )
     else:
         # Otherwise just grab the field name.
-        return _get_field(svl_plot[axis])
+        return _get_field_name(svl_plot[axis])
 
 
 def _get_bins(svl_plot):

--- a/test/test_plotly.py
+++ b/test/test_plotly.py
@@ -1,6 +1,7 @@
 import pytest
 
 from svl.plotly.plotly import (
+    _get_field_name,
     _extract_all_traces,
     _get_bins,
     _get_title,
@@ -135,6 +136,36 @@ def color_by_agged_data():
         "y": [99, 98, 99],
         "color_by": [0.3, 0.2, 0.1],
     }
+
+
+def test_get_field_name_transform():
+    """ Tests that the _get_field_name function returns the correct value
+        when the svl axis has a transform.
+    """
+    svl_axis = {"transform": "x+1"}
+    truth = "x+1"
+    answer = _get_field_name(svl_axis)
+    assert truth == answer
+
+
+def test_get_field_name_field():
+    """ Tests that the _get_field_name function returns the correct value
+        when the svl axis has a field.
+    """
+    svl_axis = {"field": "date"}
+    truth = "date"
+    answer = _get_field_name(svl_axis)
+    assert truth == answer
+
+
+def test_get_field_name_none():
+    """ Tests that the _get_field_name function returns the correct value when
+        there is no field in the SVL axis.
+    """
+    svl_axis = {"agg": "MAX"}
+    truth = "*"
+    answer = _get_field_name(svl_axis)
+    assert truth == answer
 
 
 def test_extract_all_traces_no_split_by(agged_data):

--- a/test/test_svl.py
+++ b/test/test_svl.py
@@ -523,3 +523,94 @@ def test_color_by():
     answer = parse_svl(svl_string)
 
     assert truth == answer
+
+
+def test_split_by_transform():
+    """ Tests that the SPLIT BY directive with a TRANSFORM returns the
+        correct value.
+    """
+    svl_string = """
+    DATASETS
+        bigfoot "bigfoot_sightings.csv"
+    LINE bigfoot
+        X date BY YEAR
+        Y report_id COUNT
+        SPLIT BY TRANSFORM
+            "CASE WHEN temperature > 85 THEN 'hot' ELSE 'not_hot' END"
+    """
+    truth = {
+        "datasets": {"bigfoot": {"file": "bigfoot_sightings.csv"}},
+        "vcat": [
+            {
+                "data": "bigfoot",
+                "type": "line",
+                "x": {"field": "date", "temporal": "YEAR"},
+                "y": {"field": "report_id", "agg": "COUNT"},
+                "split_by": {
+                    "transform": "CASE WHEN temperature > 85 THEN 'hot' "
+                    "ELSE 'not_hot' END"
+                },
+            }
+        ],
+    }
+    answer = parse_svl(svl_string)
+
+    assert truth == answer
+
+
+def test_split_by_temporal():
+    """ Tests that the SPLIT BY directive with a TEMPORAL modifier returns
+        the correct value.
+    """
+    svl_string = """
+    DATASETS bigfoot "bigfoot_sightings.csv"
+    BAR bigfoot
+        X classification
+        Y report_number COUNT
+        SPLIT BY date BY YEAR
+    """
+    truth = {
+        "datasets": {"bigfoot": {"file": "bigfoot_sightings.csv"}},
+        "vcat": [
+            {
+                "data": "bigfoot",
+                "type": "bar",
+                "x": {"field": "classification"},
+                "y": {"field": "report_number", "agg": "COUNT"},
+                "split_by": {"field": "date", "temporal": "YEAR"},
+            }
+        ],
+    }
+
+    answer = parse_svl(svl_string)
+    assert truth == answer
+
+
+def test_split_by_label():
+    """ Tests that the SPLIT BY directive with a LABEL modifier returns
+        the correct value.
+    """
+    svl_string = """
+    DATASETS bigfoot "bigfoot_sightings.csv"
+    HISTOGRAM bigfoot
+        X temperature
+        SPLIT BY classification LABEL "Classification"
+    """
+
+    truth = {
+        "datasets": {"bigfoot": {"file": "bigfoot_sightings.csv"}},
+        "vcat": [
+            {
+                "data": "bigfoot",
+                "type": "histogram",
+                "x": {"field": "temperature"},
+                "split_by": {
+                    "field": "classification",
+                    "label": "Classification",
+                },
+            }
+        ],
+    }
+
+    answer = parse_svl(svl_string)
+    assert truth == answer


### PR DESCRIPTION
Adds transform, temporal and label modifiers to `SPLIT BY` axes. Currently label modifiers are a no-op, but the syntax is valid.